### PR TITLE
Class-based Snapshot Transformers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint:
 
 
 install: clean
-	$(PYTHON) -m pip install .
+	$(PYTHON) -m pip install --use-feature=in-tree-build .
 
 
 test: lint install
@@ -35,4 +35,3 @@ deploy: test
 	git checkout master
 	$(PYTHON) setup.py sdist bdist_wheel
 	$(PYTHON) -m twine upload dist/*
-

--- a/src/rom_operator_inference/_core/__init__.py
+++ b/src/rom_operator_inference/_core/__init__.py
@@ -109,9 +109,6 @@ def load_model(loadfile):
     import os
     import h5py
 
-    if not os.path.isfile(loadfile):
-        raise FileNotFoundError(loadfile)
-
     with h5py.File(loadfile, 'r') as data:
         if "meta" not in data:
             raise ValueError("invalid save format (meta/ not found)")

--- a/src/rom_operator_inference/pre/_shift_scale.py
+++ b/src/rom_operator_inference/pre/_shift_scale.py
@@ -125,7 +125,10 @@ class SnapshotTransformer:
         "minmaxabs",
     }
 
-    def __init__(self, scaling=None, center=False, verbose=0):
+    _table_header = "    |     min    |    mean    |     max    |    std\n"
+    _table_header += "----|------------|------------|------------|------------"
+
+    def __init__(self, scaling=None, center=False, verbose=False):
         """Set transformation hyperparameters.
 
         Parameters
@@ -139,11 +142,8 @@ class SnapshotTransformer:
             * 'minmaxabs': absolute min-max scaling to [-1,1] (mean shift).
         center : bool
             If True, shift the (scaled) snapshots by the mean snapshot.
-        verbose : int
-            Verbosity level. Options:
-            * 0 (default): no printouts.
-            * 1: some printouts.
-            * 2: lots of printouts.
+        verbose : bool
+            If True, print information about the learned transformation.
 
         Notes
         -----
@@ -205,11 +205,22 @@ class SnapshotTransformer:
         self._clear()
         self.__scaling = scl
 
-    # Reporting ---------------------------------------------------------------
+    # Printing ----------------------------------------------------------------
+    def __str__(self):
+        """String representation: scaling type + centering bool."""
+        out = ["Snapshot transformer"]
+        if self.scaling:
+            out.append(f"with '{self.scaling}' scaling")
+            if self.center:
+                out.append("and mean-snapshot centering")
+        elif self.centering:
+            out.append("with mean-snapshot centering")
+        return ' '.join(out)
+
     @staticmethod
     def _statistics_report(X):
         """Return a string of basis statistics about a data set."""
-        return " | ".join([f"{f(X):<10.3e}"
+        return " | ".join([f"{f(X):>10.3e}"
                            for f in (np.min, np.mean, np.max, np.std)])
 
     # Persistence -------------------------------------------------------------
@@ -257,6 +268,12 @@ class SnapshotTransformer:
         """
         Y = X if inplace else X.copy()
 
+        # Record statistics of the training data.
+        if self.verbose:
+            report = [""]
+            report.append(self._table_header)
+            report.append(f"X   | {self._statistics_report(X)}")
+
         # Scale (non-dimensionalize) each variable.
         if self.scaling:
             # Standard: X' = (X - µ)/σ
@@ -296,21 +313,25 @@ class SnapshotTransformer:
             Y *= self.scale_
             Y += self.shift_
 
+            if self.verbose:
+                report[0] = f"Learned {self.scaling} scaling X -> X'"
+                report.append(f"X'  | {self._statistics_report(Y)}")
+
         # Center the scaled snapshots.
         if self.center:
             self.mean_ = np.mean(Y, axis=1)
             Y -= self.mean_.reshape((-1,1))
 
-        if self.verbose >= 1:
+            if self.verbose:
+                if self.scaling:
+                    report[0] += " and mean centering X' -> X''"
+                else:
+                    report[0] = "Learned mean centering X -> X''"
+                report.append(f"X'' | {self._statistics_report(Y)}")
+
+        if self.verbose:
             if self.scaling is None and self.center is False:
-                report = ["No scaling learned!"]
-            else:
-                report = [f"Learned {self.scaling} scaling X -> X'"]
-            report.append("   |     min    |    mean    |     max    |    std")
-            sep = '-'*12
-            report.append(f"---|{sep}|{sep}|{sep}|{sep}")
-            report.append(f"X  | {self._statistics_report(X)}")
-            report.append(f"X' | {self._statistics_report(Y)}")
+                report[0] = "No transformation learned"
             print('\n'.join(report))
 
         return Y
@@ -372,6 +393,257 @@ class SnapshotTransformer:
             Y /= self.scale_
 
         return Y
+
+
+# class MultivariableSnapshotTransformer:
+#     """Convenience class for processing snapshots by scaling variables
+#     (non-dimensionalization) and/or shifting by the mean snapshot.
+#     """
+#     _VALID_SCALES = ("minmax", "minmaxsym", "minmaxpos", "standard")
+#
+#     def __init__(self, num_variables=1, variable_names=None,
+#                  scale=None, shift=False, verbose=0):
+#         """Set transformation hyperparameters.
+#
+#         Parameters
+#         ----------
+#         num_variables : int ≥ 1
+#             Number of distinct variables represented by the snapshots.
+#             If the snapshots have n rows, then n must be evenly divisible by
+#             num_variables. Then dof = n / num_variables is assumed to be the
+#             number of degrees of freedom for each variables.
+#
+#         variable_names : list, tuple, or None
+#             Labels for the distinct variables represented by the snapshots.
+#             Must have length `num_variables`. If None, default to
+#             (0, 1, ..., num_variables - 1).
+#
+#         scale : bool, str, or None
+#             If given, scale (non-dimensionalize) each variable entrywise
+#             * [a,b] : min-max scaling to [a,b]
+#             * 'minmax' or 'minmaxsym' or [-1,1]: minmax scaling to [-1,1]
+#             * 'minmaxpos' or [0,1]: min-max scaling to [0,1].
+#             * 'standard' or True: normalize variable to have zero mean and
+#                 unit standard deviation.
+#             * list of length `num_variables`: scaling pattern for each of the
+#                 num_variables in the list, e.g., [[0,1], [-1,1], 'standard']
+#                scales variable 0 to [0,1], variable 1 to [-1,1], and variable
+#                 2 has a standard scaling.
+#
+#         shift : bool
+#             If given, shift the (scaled) snapshots by the mean snapshot.
+#
+#         verbose : int
+#             Verbosity level. Options:
+#             * 0 (default): no printouts.
+#             * 1: some printouts.
+#             * 2: lots of printouts.
+#         """
+#         self.num_variables = num_variables
+#         self.variable_names = variable_names
+#         self.scaling = scale
+#         self.shift = shift
+#         self.verbose = verbose
+#
+#     def _clear(self):
+#         """Delete all learned attributes."""
+#         for attr in self.__dict__:
+#             if attr.endswith('_'):
+#                 delattr(self, attr)
+#
+#     # Properties ------------------------------------------------------------
+#     @property
+#     def num_variables(self):
+#         """Number of distinct variables represented by the snapshots.
+#         If the snapshots have n rows, then n must be evenly divisible by
+#         num_variables. Then dof = n / num_variables is assumed to be the
+#         number of degrees of freedom for each variables.
+#         """
+#         return self.__nv
+#
+#     @num_variables.setter
+#     def num_variables(self, nv):
+#         """Set the number of variables, clearing the transformation."""
+#         if (nv // 1) != nv:
+#             raise TypeError("num_variables must be an integer")
+#         self.clear()
+#         self.__nv = nv
+#
+#     @property
+#     def variable_names(self):
+#         """Labels for the distinct variables represented by the snapshots.
+#         Must have length `num_variables`.
+#         """
+#         return self.__names
+#
+#     @variable_names.setter
+#     def variables_names(self, names):
+#         if names is None:
+#             self.__name = tuple(range(self.num_variables))
+#         if not isinstance(names, (int,tuple)):
+#             raise TypeError("variables_names must be list or tuple")
+#         if len(names) != self.num_variables:
+#             raise ValueError(f"{len(variable_names)} = len(variable_names) "
+#                              f"!= num_variables = {num_variables}")
+#         self.__name = variables_names
+#
+#     def _check_single_scale(self, s):
+#         """Validate an individual scaling directive."""
+#         if isinstance(s, str):
+#             if s not in self._VALID_SCALES:
+#                 raise ValueError(f"invalid scaling '{s}'")
+#         elif isinstance(s, (list, tuple)):
+#             if len(s) != 2 or s[0] >= s[1]:
+#                 raise ValueError(f"invalid scaling '{s}'")
+#         elif s is not True:
+#             raise TypeError(f"invalid scaling '{s}' of type '{type(s)}'")
+#         return s
+#
+#     @property
+#     def scale(self):
+#         """Scaling (non-dimensionalize) directives for each variable.
+#         * [a,b] : min-max scaling to [a,b]
+#         * 'minmax' or 'minmaxsym' or [-1,1]: minmax scaling to [-1,1]
+#         * 'minmaxpos' or [0,1]: min-max scaling to [0,1].
+#         * 'standard': normalize variable to have zero mean and
+#             unit standard deviation.
+#         * list of length `num_variables`: scaling pattern for each of the
+#             num_variables in the list, e.g., [[0,1], [-1,1], 'standard']
+#             scales variable 0 to [0,1], variable 1 to [-1,1], and variable
+#             2 has a standard scaling.
+#         """
+#         return self.__scale
+#
+#     @scale.setter
+#     def scale(self, scale):
+#         """Set the scale."""
+#         if scale is None:
+#             self.__scale = scale
+#             return
+#
+#         if self.num_variables == 1 and (isinstance(scale, (list, tuple))
+#                                         and len(scale) == 2):
+#             scale = [scale]
+#         elif not (isinstance(scale, (list, tuple))
+#                   and len(scale) != self.num_variables):
+#             scale = [scale]
+#
+#         scales = [self._check_single_scale(s) for s in scale]
+#         if len(scales) != self.num_variables:
+#             raise ValueError(f"expected {self.num_variables} scales, "
+#                              f"got {len(scales)}")
+#         self.__scale = scales
+#
+#     def fit_transform(self, X, weights=None, inplace=False):
+#         """Learn the transformation from a collection of snapshots.
+#
+#         Parameters
+#         ----------
+#         X : (n,k) ndarray
+#             Matrix of k snapshots. Each column is a snapshot of dimension n.
+#
+#         weights: (k,) ndarray or None
+#             Weights for determining the mean shift.
+#
+#         inplace : bool
+#             If True, overwrite the input data during transformation.
+#             If False, create a copy of the data to transform.
+#
+#         Returns
+#         -------
+#         self
+#         """
+#         n, r = X.shape
+#
+#         # Scale (non-dimensionalize) each variable.
+#         if self.scaling:
+#             variables = np.split(X, self.num_variables, axis=0)
+#         if self.scaling == "standard":
+#             self.means_ = np.array([np.mean(v) for v in variables])
+#             self.stds_ = np.array([np.std(v) for v in variables])
+#         elif self.scaling == "minmax":
+#             self.mins_ = np.array([np.min(v) for v in variables])
+#             self.maxs_ = np.array([np.max(v) for v in variables])
+#
+#         # TODO: Shift (center) the scaled snapshots.
+#
+#         return X
+#
+#         # Determine whether learning the scaling transformation is needed.
+#         learning = (scales is None)
+#         if learning:
+#             if variables is not None:
+#                 raise ValueError("scale=None only valid for variables=None")
+#             scales = np.empty((config.NUM_ROMVARS, 2), dtype=np.float)
+#         else:
+#             # Validate the scales.
+#             _shape = (config.NUM_ROMVARS, 2)
+#             if scales.shape != _shape:
+#                 raise ValueError(f"`scales` must have shape {_shape}")
+#
+#         # Parse the variables.
+#         if variables is None:
+#             variables = config.ROM_VARIABLES
+#         elif isinstance(variables, str):
+#             variables = [variables]
+#         varindices = [config.ROM_VARIABLES.index(v) for v in variables]
+#
+#         # Make sure the data can be split correctly by variable.
+#         nchunks = len(variables)
+#         chunksize, remainder = divmod(data.shape[0], nchunks)
+#         if remainder != 0:
+#             raise ValueError("data to scale cannot be split"
+#                              f" evenly into {nchunks} chunks")
+#
+#         # Do the scaling by variable.
+#         for i,vidx in enumerate(varindices):
+#             s = slice(i*chunksize,(i+1)*chunksize)
+#             if learning:
+#                 assert i == vidx
+#                 if variables[i] in ["p", "T", "xi"]:
+#                     scales[vidx,0] = np.mean(data[s])
+#                     shifted = data[s] - scales[vidx,0]
+#                 else:
+#                     scales[vidx,0] = 0
+#                     shifted = data[s]
+#                 scales[vidx,1] = np.abs(shifted).max()
+#                 data[s] = shifted / scales[vidx,1]
+#             else:
+#                 data[s] = (data[s] - scales[vidx,0]) / scales[vidx,1]
+#
+#         # Report info on the learned scaling.
+#         if verbose >= 1:
+#             sep = '|'.join(['-'*12]*2)
+#             report = f"""Learned new scaling
+#                            Shift    |    Denom
+#                         {sep}
+#         Pressure        {scales[0,0]:<12.3e}|{scales[0,1]:>12.3e}
+#                         {sep}
+#         x-velocity      {scales[1,0]:<12.3f}|{scales[1,1]:>12.3f}
+#                         {sep}
+#         y-velocity      {scales[2,0]:<12.3f}|{scales[2,1]:>12.3f}
+#                         {sep}
+#         Temperature     {scales[3,0]:<12.3e}|{scales[3,1]:>12.3e}
+#                         {sep}
+#         Specific Volume {scales[4,0]:<12.3f}|{scales[4,1]:>12.3f}
+#                         {sep}
+#         CH4 molar       {scales[5,0]:<12.3f}|{scales[5,1]:>12.3f}
+#                         {sep}
+#         O2  molar       {scales[6,0]:<12.3f}|{scales[6,1]:>12.3f}
+#                         {sep}
+#         H2O molar       {scales[8,0]:<12.3f}|{scales[8,1]:>12.3f}
+#                         {sep}
+#         CO2 molar       {scales[7,0]:<12.3f}|{scales[7,1]:>12.3f}
+#                         {sep}"""
+#             logging.info(report)
+#
+#         return data, scales
+#
+#     def transform(self, X):
+#         return X
+#
+#     def untransform(self, X):
+#         return X
 
 
 # Deprecations ================================================================

--- a/src/rom_operator_inference/pre/_shift_scale.py
+++ b/src/rom_operator_inference/pre/_shift_scale.py
@@ -1,9 +1,10 @@
-# pre/_shiftscale.py
+# pre/_shift_scale.py
 """Tools for preprocessing data."""
 
 __all__ = [
             "shift",
             "scale",
+            "SnapshotTransformer"
           ]
 
 import numpy as np
@@ -17,7 +18,6 @@ def shift(X, shift_by=None):
     ----------
     X : (n,k) ndarray
         A matrix of k snapshots. Each column is a single snapshot.
-
     shift_by : (n,) or (n,1) ndarray
         A vector that is the same size as a single snapshot. If None,
         set to the mean of the columns of X.
@@ -26,13 +26,10 @@ def shift(X, shift_by=None):
     -------
     Xshifted : (n,k) ndarray
         The matrix such that Xshifted[:,j] = X[:,j] - shift_by for j=0,...,k-1.
-
     xbar : (n,) ndarray
         The shift factor. Since this is a one-dimensional array, it must be
         reshaped to be applied to a matrix: Xshifted + xbar.reshape((-1,1)).
         Only returned if shift_by=None.
-
-    For shift_by=None, only Xshifted is returned.
 
     Examples
     --------
@@ -70,10 +67,8 @@ def scale(X, scale_to, scale_from=None):
     ----------
     X : (n,k) ndarray
         A matrix of k snapshots to be scaled. Each column is a single snapshot.
-
     scale_to : (2,) tuple
         The desired minimum and maximum of the scaled data.
-
     scale_from : (2,) tuple
         The minimum and maximum of the snapshot data. If None, learn the
         scaling from X: scale_from[0] = min(X); scale_from[1] = max(X).
@@ -82,17 +77,13 @@ def scale(X, scale_to, scale_from=None):
     -------
     Xscaled : (n,k) ndarray
         The scaled snapshot matrix.
-
     scaled_to : (2,) tuple
         The bounds that the snapshot matrix was scaled to, i.e.,
         scaled_to[0] = min(Xscaled); scaled_to[1] = max(Xscaled).
         Only returned if scale_from = None.
-
     scaled_from : (2,) tuple
         The minimum and maximum of the snapshot data, i.e., the bounds that
         the data was scaled from. Only returned if scale_from = None.
-
-    For scale_from=None, only Xscaled is returned.
 
     Examples
     --------
@@ -122,6 +113,265 @@ def scale(X, scale_to, scale_from=None):
     Xscaled = X*scl + (mini - xmin*scl)
 
     return (Xscaled, scale_to, scale_from) if learning else Xscaled
+
+
+class SnapshotTransformer:
+    """Process snapshots by scaling and/or centering."""
+    _VALID_SCALINGS = {
+        "standard",
+        "minmax",
+        "symminmax",
+        "maxabs",
+        "minmaxabs",
+    }
+
+    def __init__(self, scaling=None, center=False, verbose=0):
+        """Set transformation hyperparameters.
+
+        Parameters
+        ----------
+        scaling : str or None
+            If given, scale (non-dimensionalize) the snapshot data entrywise.
+            * 'standard': standardize to zero mean and unit standard deviation.
+            * 'minmax': minmax scaling to [0,1].
+            * 'symminmax': minmax scaling to [-1,1].
+            * 'maxabs': absolute maximum scaling to [-1,1] (no shift).
+            * 'minmaxabs': absolute min-max scaling to [-1,1] (mean shift).
+        center : bool
+            If True, shift the (scaled) snapshots by the mean snapshot.
+        verbose : int
+            Verbosity level. Options:
+            * 0 (default): no printouts.
+            * 1: some printouts.
+            * 2: lots of printouts.
+
+        Notes
+        -----
+        Standard scaling:
+            X' = (X - mean(X)) / std(X);
+            Guarantees mean(X') = 0, std(X') = 1.
+        Min-max scaling:
+            X' = (X - min(X))/(max(X) - min(X));
+            Guarantees min(X') = 0, max(X') = 1.
+        Symmetric min-max scaling:
+            X' = (X - min(X))*2/(max(X) - min(X)) - 1
+            Guarantees min(X') = -1, max(X') = 1.
+        Maximum absolute scaling:
+            X' = X / max(abs(X));
+            Guarantees mean(X') = mean(X) / max(abs(X)), max(abs(X')) = 1.
+        Min-max absolute scaling:
+            X' = (X - mean(X)) / max(abs(X - mean(X)));
+            Guarantees mean(X') = 0, max(abs(X')) = 1.
+        Centering:
+            X'' = X' - mean(X', axis=1);
+            Guarantees mean(X'', axis=1) = [0, ..., 0].
+        """
+        self.scaling = scaling
+        self.center = center
+        self.verbose = verbose
+
+    def _clear(self):
+        """Delete all learned attributes."""
+        for attr in ("scale_", "shift_", "mean_"):
+            if hasattr(self, attr):
+                delattr(self, attr)
+
+    # Properties --------------------------------------------------------------
+    @property
+    def scaling(self):
+        """Entrywise scaling (non-dimensionalization) directive.
+        * None: no scaling.
+        * 'standard': standardize to zero mean and unit standard deviation.
+        * 'minmax': minmax scaling to [0,1].
+        * 'symminmax': minmax scaling to [-1,1].
+        * 'maxabs': absolute maximum scaling to [-1,1] (no shift).
+        * 'minmaxabs': absolute min-max scaling to [-1,1] (mean shift).
+        """
+        return self.__scaling
+
+    @scaling.setter
+    def scaling(self, scl):
+        """Set the scaling strategy, checking for validity."""
+        if scl is None:
+            self._clear()
+            self.__scaling = scl
+            return
+        if not isinstance(scl, str):
+            raise TypeError("'scaling' must be of type 'str'")
+        if scl not in self._VALID_SCALINGS:
+            opts = ", ".join([f"'{v}'" for v in self._VALID_SCALINGS])
+            raise ValueError(f"invalid scaling '{scl}'; "
+                             f"valid options are {opts}")
+        self._clear()
+        self.__scaling = scl
+
+    # Reporting ---------------------------------------------------------------
+    @staticmethod
+    def _statistics_report(X):
+        """Return a string of basis statistics about a data set."""
+        return " | ".join([f"{f(X):<10.3e}"
+                           for f in (np.min, np.mean, np.max, np.std)])
+
+    # Persistence -------------------------------------------------------------
+    def save(self, filename, overwrite=False):
+        """Save the current transformer to an HDF5 file.
+
+        Parameters
+        ----------
+        filename : str
+            Path of the file to save the transformer in.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def load(cls, filename):
+        """Load a SnapshotTransformer from an HDF5 file.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the file where the transformer was stored (via save()).
+
+        Returns
+        -------
+            SnapshotTransformer
+        """
+        raise NotImplementedError
+
+    # Main routines -----------------------------------------------------------
+    def fit_transform(self, X, inplace=False):
+        """Learn and apply the transformation.
+
+        Parameters
+        ----------
+        X : (n,k) ndarray
+            Matrix of k snapshots. Each column is a snapshot of dimension n.
+        inplace : bool
+            If True, overwrite the input data during transformation.
+            If False, create a copy of the data to transform.
+
+        Returns
+        -------
+        X'': (n,k) ndarray
+            Matrix of k transformed n-dimensional snapshots.
+        """
+        Y = X if inplace else X.copy()
+
+        # Scale (non-dimensionalize) each variable.
+        if self.scaling:
+            # Standard: X' = (X - µ)/σ
+            if self.scaling == "standard":
+                µ = np.mean(X)
+                σ = np.std(X)
+                self.scale_ = 1/σ
+                self.shift_ = -µ*self.scale_
+
+            # Min-max: X' = (X - min(X))/(max(X) - min(X))
+            elif self.scaling == "minmax":
+                Xmin = np.min(X)
+                Xmax = np.max(X)
+                self.scale_ = 1/(Xmax - Xmin)
+                self.shift_ = -Xmin*self.scale_
+
+            # Symmetric min-max: X' = (X - min(X))*2/(max(X) - min(X)) - 1
+            elif self.scaling == "symminmax":
+                Xmin = np.min(X)
+                Xmax = np.max(X)
+                self.scale_ = 2/(Xmax - Xmin)
+                self.shift_ = -Xmin*self.scale_ - 1
+
+            # MaxAbs: X' = X / max(abs(X))
+            elif self.scaling == "maxabs":
+                self.scale_ = 1/np.max(np.abs(X))
+                self.shift_ = 0
+
+            # MinMaxAbs: X' = (X - mean(X)) / max(abs(X - mean(X)))
+            elif self.scaling == "minmaxabs":
+                µ = np.mean(X)
+                Y -= µ
+                self.scale_ = 1/np.max(np.abs(Y))
+                self.shift_ = -µ*self.scale_
+                Y += µ
+
+            Y *= self.scale_
+            Y += self.shift_
+
+        # Center the scaled snapshots.
+        if self.center:
+            self.mean_ = np.mean(Y, axis=1)
+            Y -= self.mean_.reshape((-1,1))
+
+        if self.verbose >= 1:
+            if self.scaling is None and self.center is False:
+                report = ["No scaling learned!"]
+            else:
+                report = [f"Learned {self.scaling} scaling X -> X'"]
+            report.append("   |     min    |    mean    |     max    |    std")
+            sep = '-'*12
+            report.append(f"---|{sep}|{sep}|{sep}|{sep}")
+            report.append(f"X  | {self._statistics_report(X)}")
+            report.append(f"X' | {self._statistics_report(Y)}")
+            print('\n'.join(report))
+
+        return Y
+
+    def transform(self, X, inplace=False):
+        """Apply the learned transformation.
+
+        Parameters
+        ----------
+        X : (n,k) ndarray
+            Matrix of k snapshots. Each column is a snapshot of dimension n.
+        inplace : bool
+            If True, overwrite the input data during transformation.
+            If False, create a copy of the data to transform.
+
+        Returns
+        -------
+        X'': (n,k) ndarray
+            Matrix of k transformed n-dimensional snapshots.
+        """
+        Y = X if inplace else X.copy()
+
+        # Scale (non-dimensionalize) each variable.
+        if self.scaling:
+            Y *= self.scale_
+            Y += self.shift_
+
+        # Shift (center) the scaled snapshots.
+        if self.center:
+            Y -= self.mean_.reshape((-1,1))
+
+        return Y
+
+    def inverse_transform(self, X, inplace=False):
+        """Apply the inverse of the learned transformation.
+
+        Parameters
+        ----------
+        X : (n,k) ndarray
+            Matrix of k transformed n-dimensional snapshots.
+        inplace : bool
+            If True, overwrite the input data during inverse transformation.
+            If False, create a copy of the data to untransform.
+
+        Returns
+        -------
+        X'': (n,k) ndarray
+            Matrix of k untransformed n-dimensional snapshots.
+        """
+        Y = X if inplace else X.copy()
+
+        # Shift (uncenter) the scaled snapshots.
+        if self.center:
+            Y += self.mean_.reshape((-1,1))
+
+        # Unscale (re-dimensionalize) the unshifted snapshots.
+        if self.scaling:
+            Y -= self.shift_
+            Y /= self.scale_
+
+        return Y
 
 
 # Deprecations ================================================================

--- a/tests/_core/test_init.py
+++ b/tests/_core/test_init.py
@@ -63,16 +63,13 @@ def test_load_model():
     Vr = np.random.random((n,r))
     c_, A_, H_, G_, B_ = _get_operators(n=r, m=m)
 
-    # Try loading a file that does not exist.
-    target = "loadmodeltest.h5"
+    # Clean up after old tests if needed.
+    target = "_loadmodeltest.h5"
     if os.path.isfile(target):                  # pragma: no cover
         os.remove(target)
-    with pytest.raises(FileNotFoundError) as ex:
-        rom = opinf.load_model(target)
-    assert ex.value.args[0] == target
 
     # Make an empty HDF5 file to start with.
-    with h5py.File(target, 'w') as f:
+    with h5py.File(target, 'w'):
         pass
 
     with pytest.raises(ValueError) as ex:

--- a/tests/pre/test_shift_scale.py
+++ b/tests/pre/test_shift_scale.py
@@ -108,7 +108,7 @@ class TestSnapshotTransformer:
 
         X = np.random.randint(0, 100, (n,k)).astype(float)
         st = opinf.pre.SnapshotTransformer(scaling=None,
-                                           center=False, verbose=0)
+                                           center=False, verbose=False)
 
         # Test null transformation.
         Y = st.fit_transform(X, inplace=True)
@@ -199,7 +199,7 @@ class TestSnapshotTransformer:
         """Test pre.SnapshotTransformer.transform()."""
         X = np.random.randint(0, 100, (n,k)).astype(float)
         st = opinf.pre.SnapshotTransformer(scaling=None,
-                                           center=False, verbose=0)
+                                           center=False, verbose=False)
 
         for scaling, center in itertools.product({None, *st._VALID_SCALINGS},
                                                  (True, False)):
@@ -210,3 +210,48 @@ class TestSnapshotTransformer:
             Z = st.transform(Y, inplace=False)
             st.inverse_transform(Z, inplace=True)
             assert np.allclose(Z, Y)
+
+
+# class TestMultivariableSnapshotTransformer:
+#     """Test pre.MultivariableSnapshotTransformer."""
+#     def test_init(self):
+#         """Test pre.MultivariableSnapshotTransformer.__init__()."""
+#         st = opinf.pre.MultivariableSnapshotTransformer()
+#         for attr in ["num_variables", "scale", "shift", "inplace",
+#                      "variable_names", "weights", "verbose"]:
+#             assert hasattr(st, attr)
+#
+#     def test_properties(self):
+#         """Test pre.SnapshotTransformer properties (attribute protection)."""
+#         st = opinf.pre.SnapshotTransformer()
+#
+#         # Test num_variables.
+#         with pytest.raises(TypeError) as exc:
+#             st.num_variables = 1.5
+#         assert exc.value.args[0] == "num_variables must be an integer"
+#
+#         st.num_variables = 1
+#         st.num_variables = 2
+#         st.num_variables = 3.0
+#
+#         # Test variable_names.
+#         st.num_variables = 1
+#         with pytest.raises(ValueError) as exc:
+#             st.variable_names = [0, 1]
+#         assert exc.value.args[0] == \
+#             "2 = len(variable_names) != num_variables = 1"
+#         st.variable_names = "fred"
+#
+#         # Test scale.
+#         st.num_variables = 1
+#         with pytest.raises(ValueError) as exc:
+#             st.scaling = "minimaxi"
+#         assert exc.value.args[0] == "invalid scaling 'minimaxi'"
+#
+#         with pytest.raises(ValueError) as exc:
+#             st.scaling = [2, 1]
+#         assert exc.value.args[0] == "invalid scaling '[2, 1]'"
+#
+#         for s in list(st._VALID_SCALINGS) + [True, [-3, 7]]:
+#             st.scaling = s
+#             assert st.scaling == [s]

--- a/tests/pre/test_shift_scale.py
+++ b/tests/pre/test_shift_scale.py
@@ -70,6 +70,7 @@ def test_scale(set_up_basis_data):
     assert np.allclose(opinf.pre.scale(Xscaled, scaled_from, scaled_to), X)
 
 
+# Transformer classes for centering and scaling ===============================
 class TestSnapshotTransformer:
     """Test pre.SnapshotTransformer."""
     def test_init(self):
@@ -78,6 +79,7 @@ class TestSnapshotTransformer:
         for attr in ["scaling", "center", "verbose"]:
             assert hasattr(st, attr)
 
+    # Properties --------------------------------------------------------------
     def test_properties(self):
         """Test pre.SnapshotTransformer properties (attribute protection)."""
         st = opinf.pre.SnapshotTransformer()
@@ -101,30 +103,6 @@ class TestSnapshotTransformer:
         for s in st._VALID_SCALINGS:
             st.scaling = s
         st.scaling = None
-
-    def test_is_trained(self):
-        """Test pre.SnapshotTransformer._is_trained()."""
-        st = opinf.pre.SnapshotTransformer()
-
-        # Null transformer is always trained.
-        st.center = False
-        st.scaling = None
-        assert st._is_trained() is True
-
-        # Centering.
-        st.center = True
-        assert st._is_trained() is False
-        st.mean_ = np.array([1,2,3])
-        assert st._is_trained() is True
-
-        # Scaling.
-        st.center = False
-        st.scaling = "minmax"
-        assert st._is_trained() is False
-        st.scale_ = 10
-        assert st._is_trained() is False
-        st.shift_ = 20
-        assert st._is_trained() is True
 
     def test_eq(self, n=200):
         """Test pre.SnapshotTransformer.__eq__()."""
@@ -167,6 +145,7 @@ class TestSnapshotTransformer:
         st2.scale_, st2.shift_ = a, b
         assert st1 == st2
 
+    # Printing ----------------------------------------------------------------
     def test_str(self):
         """Test pre.SnapshotTransformer.__str__()."""
         st = opinf.pre.SnapshotTransformer()
@@ -176,16 +155,17 @@ class TestSnapshotTransformer:
         assert str(st) == "Snapshot transformer"
 
         st.center = True
+        trn = "(call fit_transform() to train)"
         msc = "Snapshot transformer with mean-snapshot centering"
-        assert str(st) == msc
+        assert str(st) == f"{msc} {trn}"
         for s in st._VALID_SCALINGS:
             st.scaling = s
-            assert str(st) == f"{msc} and '{s}' scaling"
+            assert str(st) == f"{msc} and '{s}' scaling {trn}"
 
         st.center = False
         for s in st._VALID_SCALINGS:
             st.scaling = s
-            assert str(st) == f"Snapshot transformer with '{s}' scaling"
+            assert str(st) == f"Snapshot transformer with '{s}' scaling {trn}"
 
     def test_statistics_report(self):
         """Test pre.SnapshotTransformer._statistics_report()."""
@@ -193,6 +173,7 @@ class TestSnapshotTransformer:
         report = opinf.pre.SnapshotTransformer._statistics_report(X)
         assert report == "-4.000e+00 |  5.000e-01 |  5.000e+00 |  2.872e+00"
 
+    # Persistence -------------------------------------------------------------
     def test_save(self, n=200, k=50):
         """Test pre.SnapshotTransformer.save()."""
         # Clean up after old tests.
@@ -230,7 +211,7 @@ class TestSnapshotTransformer:
 
         with pytest.raises(FileExistsError) as ex:
             st.save(target, overwrite=False)
-        assert ex.value.args[0] == target
+        ex.value.args[0] == f"{target} (use overwrite=True to ignore)"
 
         st.save(target, overwrite=True)
         _checkfile(target, st)
@@ -275,6 +256,31 @@ class TestSnapshotTransformer:
             assert st == st2
 
         os.remove(target)
+
+    # Main routines -----------------------------------------------------------
+    def test_is_trained(self):
+        """Test pre.SnapshotTransformer._is_trained()."""
+        st = opinf.pre.SnapshotTransformer()
+
+        # Null transformer is always trained.
+        st.center = False
+        st.scaling = None
+        assert st._is_trained() is True
+
+        # Centering.
+        st.center = True
+        assert st._is_trained() is False
+        st.mean_ = np.array([1,2,3])
+        assert st._is_trained() is True
+
+        # Scaling.
+        st.center = False
+        st.scaling = "minmax"
+        assert st._is_trained() is False
+        st.scale_ = 10
+        assert st._is_trained() is False
+        st.shift_ = 20
+        assert st._is_trained() is True
 
     def test_fit_transform(self, n=200, k=50):
         """Test pre.SnapshotTransformer.fit_transform()."""
@@ -406,46 +412,431 @@ class TestSnapshotTransformer:
             assert np.allclose(Z, Y)
 
 
-# class TestMultivariableSnapshotTransformer:
-#     """Test pre.MultivariableSnapshotTransformer."""
-#     def test_init(self):
-#         """Test pre.MultivariableSnapshotTransformer.__init__()."""
-#         st = opinf.pre.MultivariableSnapshotTransformer()
-#         for attr in ["num_variables", "scale", "shift", "inplace",
-#                      "variable_names", "weights", "verbose"]:
-#             assert hasattr(st, attr)
-#
-#     def test_properties(self):
-#         """Test pre.SnapshotTransformer properties (attribute protection)."""
-#         st = opinf.pre.SnapshotTransformer()
-#
-#         # Test num_variables.
-#         with pytest.raises(TypeError) as ex:
-#             st.num_variables = 1.5
-#         assert ex.value.args[0] == "num_variables must be an integer"
-#
-#         st.num_variables = 1
-#         st.num_variables = 2
-#         st.num_variables = 3.0
-#
-#         # Test variable_names.
-#         st.num_variables = 1
-#         with pytest.raises(ValueError) as ex:
-#             st.variable_names = [0, 1]
-#         assert ex.value.args[0] == \
-#             "2 = len(variable_names) != num_variables = 1"
-#         st.variable_names = "fred"
-#
-#         # Test scale.
-#         st.num_variables = 1
-#         with pytest.raises(ValueError) as ex:
-#             st.scaling = "minimaxi"
-#         assert ex.value.args[0] == "invalid scaling 'minimaxi'"
-#
-#         with pytest.raises(ValueError) as ex:
-#             st.scaling = [2, 1]
-#         assert ex.value.args[0] == "invalid scaling '[2, 1]'"
-#
-#         for s in list(st._VALID_SCALINGS) + [True, [-3, 7]]:
-#             st.scaling = s
-#             assert st.scaling == [s]
+class TestSnapshotTransformerMulti:
+    """Test pre.SnapshotTransformerMulti."""
+    def test_init(self):
+        """Test pre.SnapshotTransformer.__init__()."""
+        stm = opinf.pre.SnapshotTransformerMulti(1)
+        for attr in ["scaling", "center", "verbose",
+                     "num_variables", "transformers"]:
+            assert hasattr(stm, attr)
+
+        # Center.
+        stm = opinf.pre.SnapshotTransformerMulti(2, center=(True, True))
+        assert stm.center == (True, True)
+        stm.transformers[1].center = False
+        assert stm.center == (True, False)
+        stm = opinf.pre.SnapshotTransformerMulti(3, center=True)
+        assert stm.center == (True, True, True)
+        with pytest.raises(ValueError) as ex:
+            opinf.pre.SnapshotTransformerMulti(3, center=[True, False])
+        assert ex.value.args[0] == "len(center) = 2 != 3 = num_variables"
+        with pytest.raises(ValueError) as ex:
+            opinf.pre.SnapshotTransformerMulti(3, center="the center")
+        assert ex.value.args[0] == "len(center) = 10 != 3 = num_variables"
+        with pytest.raises(TypeError) as ex:
+            opinf.pre.SnapshotTransformerMulti(3, center=100)
+        assert ex.value.args[0] == "object of type 'int' has no len()"
+        with pytest.raises(TypeError) as ex:
+            opinf.pre.SnapshotTransformerMulti(2, center=(True, "yes"))
+        assert ex.value.args[0] == "'center' must be True or False"
+
+        # Scaling.
+        stm = opinf.pre.SnapshotTransformerMulti(2, scaling=("minmax", None))
+        assert stm.scaling == ("minmax", None)
+        stm = opinf.pre.SnapshotTransformerMulti(2, scaling=[None, "maxabs"])
+        assert isinstance(stm.scaling, tuple)
+        assert stm.scaling == (None, "maxabs")
+        stm = opinf.pre.SnapshotTransformerMulti(3, scaling="standard")
+        assert stm.scaling == ("standard", "standard", "standard")
+        with pytest.raises(TypeError) as ex:
+            opinf.pre.SnapshotTransformerMulti(3, scaling=100)
+        assert ex.value.args[0] == "object of type 'int' has no len()"
+        with pytest.raises(ValueError) as ex:
+            opinf.pre.SnapshotTransformerMulti(3, scaling=(True, False))
+        assert ex.value.args[0] == "len(scaling) = 2 != 3 = num_variables"
+        with pytest.raises(TypeError) as ex:
+            opinf.pre.SnapshotTransformerMulti(2, scaling=(True, "minmax"))
+        assert ex.value.args[0] == "'scaling' must be of type 'str'"
+
+    # Properties --------------------------------------------------------------
+    def test_properties(self):
+        """Test pre.SnapshotTransformerMulti properties."""
+
+        # Attribute setting blocked.
+        stm = opinf.pre.SnapshotTransformerMulti(2)
+        for attr in "num_variables", "center", "scaling":
+            assert hasattr(stm, attr)
+            with pytest.raises(AttributeError) as ex:
+                setattr(stm, attr, 0)
+            assert ex.value.args[0] == "can't set attribute"
+
+        # Variable names.
+        stm = opinf.pre.SnapshotTransformerMulti(3, variable_names=None)
+        assert isinstance(stm.variable_names, list)
+        assert len(stm.variable_names) == 3
+        assert stm.variable_names == ["variable 1", "variable 2", "variable 3"]
+        with pytest.raises(TypeError) as ex:
+            stm.variable_names = (1, 2, 3)
+        assert ex.value.args[0] == "variable_names must be list of length 3"
+        with pytest.raises(TypeError) as ex:
+            stm.variable_names = [1, 2]
+        assert ex.value.args[0] == "variable_names must be list of length 3"
+        stm.variable_names = ["Bill", "Charlie", "Percy"]
+
+        # Verbose
+        stm.verbose = 1
+        assert stm.verbose is True
+        stm.verbose = 0
+        assert stm.verbose is False
+        assert all(st.verbose is False for st in stm.transformers)
+        stm.verbose = True
+        assert stm.verbose is True
+
+    def test_mean(self):
+        """Test pre.SnapshotTransformerMulti.mean_."""
+        centers = [False, True, False, True]
+        scalings = [None, None, "standard", "minmax"]
+        stm = opinf.pre.SnapshotTransformerMulti(4, centers, scalings)
+        assert stm.mean_ is None
+
+        # Set the centering vectors.
+        stm.n_ = 7
+        µs = [np.random.randint(0, 100, stm.n_) for _ in range(4)]
+        for i,µ in enumerate(µs):
+            if centers[i]:
+                stm.transformers[i].mean_ = µ
+            if scalings[i]:
+                stm.transformers[i].scale_ = 0
+                stm.transformers[i].shift_ = 0
+
+        # Validate concatenated mean_.
+        µµ = stm.mean_
+        assert isinstance(µµ, np.ndarray)
+        assert µµ.shape == (4*stm.n_,)
+        for i,µ in enumerate(µs):
+            s = slice(i*stm.n_, (i+1)*stm.n_)
+            if centers[i]:
+                assert np.allclose(µµ[s], µ)
+            else:
+                assert np.allclose(µµ[s], 0)
+
+    def test_len(self):
+        """Test pre.SnapshotTransformerMulti.__len__()."""
+        for i in [2, 5, 10]:
+            stm = opinf.pre.SnapshotTransformerMulti(i)
+            assert len(stm) == i
+
+    def test_getitem(self):
+        """Test pre.SnapshotTransformerMulti.__getitem__()."""
+        stm = opinf.pre.SnapshotTransformerMulti(10)
+        for i in [3, 4, 7]:
+            assert stm[i] is stm.transformers[i]
+
+    def test_setitem(self):
+        """Test pre.SnapshotTransformerMulti.__setitem__()."""
+        stm = opinf.pre.SnapshotTransformerMulti(10)
+        st = opinf.pre.SnapshotTransformer(center=True, scaling="minmax")
+        for i in [3, 4, 7]:
+            stm[i] = st
+            assert stm.transformers[i] is st
+
+        for i in range(stm.num_variables):
+            stm[i].center = False
+        assert stm.center == (False,)*stm.num_variables
+
+        with pytest.raises(TypeError) as ex:
+            stm[2] = 10
+        assert ex.value.args[0] == \
+            "assignment object must be SnapshotTransformer"
+
+    def test_eq(self):
+        """Test pre.SnapshotTransformerMulti.__eq__()."""
+        # Null transformers.
+        stm1 = opinf.pre.SnapshotTransformerMulti(3)
+        assert stm1 != 100
+        stm2 = opinf.pre.SnapshotTransformerMulti(2)
+        assert stm1 != stm2
+        stm2 = opinf.pre.SnapshotTransformerMulti(3)
+        assert stm1 == stm2
+
+        # Mismatched attributes.
+        stm1 = opinf.pre.SnapshotTransformerMulti(3, center=True)
+        stm2 = opinf.pre.SnapshotTransformerMulti(3, center=False)
+        assert not (stm1 == stm2)
+        assert stm1 != stm2
+
+        stm1 = opinf.pre.SnapshotTransformerMulti(3, scaling="minmax")
+        stm2 = opinf.pre.SnapshotTransformerMulti(3, scaling="minmax")
+        assert stm1 == stm2
+        st = opinf.pre.SnapshotTransformer(scaling="standard")
+        stm1.transformers[1] = st
+        assert stm1 != stm2
+        stm2.transformers[1] = st
+        assert stm1 == stm2
+
+    def test_str(self):
+        """Test pre.SnapshotTransformerMulti.__str__()."""
+        names = ["var1", "var2", "var3"]
+        stm = opinf.pre.SnapshotTransformerMulti(3, center=False,
+                                                 scaling=None,
+                                                 variable_names=names)
+        stm.transformers[0].center = True
+        stm.transformers[-1].scaling = "standard"
+
+        assert str(stm) == \
+            "Multi-variate snapshot transformer\n" \
+            "* var1 | Snapshot transformer with mean-snapshot centering " \
+            "(call fit_transform() to train)\n" \
+            "* var2 | Snapshot transformer\n" \
+            "* var3 | Snapshot transformer with 'standard' scaling " \
+            "(call fit_transform() to train)"
+
+    # Persistence -------------------------------------------------------------
+    def test_save(self):
+        """Test pre.SnapshotTransformerMulti.save()."""
+        # Clean up after old tests.
+        target = "_savetransformermultitest.h5"
+        if os.path.isfile(target):              # pragma: no cover
+            os.remove(target)
+
+        def _checkfile(filename, stm):
+            assert os.path.isfile(filename)
+            with h5py.File(filename, 'r') as hf:
+                # Check transformation metadata.
+                assert "meta" in hf
+                assert len(hf["meta"]) == 0
+                for attr in ("num_variables", "verbose"):
+                    assert attr in hf["meta"].attrs
+                    assert hf["meta"].attrs[attr] == getattr(stm, attr)
+
+                # Check individual transformers.
+                for i in range(stm.num_variables):
+                    label = f"variable{i+1}"
+                    assert label in hf
+                    group = hf[label]
+                    assert "meta" in group
+                    assert "center" in group["meta"].attrs
+                    assert "scaling" in group["meta"].attrs
+                    st = stm.transformers[i]
+                    assert group["meta"].attrs["center"] == st.center
+                    if st.scaling is None:
+                        assert not group["meta"].attrs["scaling"]
+                        assert group["meta"].attrs["scaling"] is not None
+                    else:
+                        assert group["meta"].attrs["scaling"] == st.scaling
+
+                    # Check transformation parameters.
+                    if st.center:
+                        assert "transformation/mean_" in group
+                        assert np.all(
+                            group["transformation/mean_"][:] == st.mean_)
+                    if st.scaling:
+                        assert "transformation/scale_" in group
+                        assert group["transformation/scale_"][0] == st.scale_
+                        assert "transformation/shift_" in group
+                        assert group["transformation/shift_"][0] == st.shift_
+
+        # Check file creation and overwrite protocol on null transformation.
+        stm = opinf.pre.SnapshotTransformerMulti(15)
+        stm.save(target[:-3])
+        _checkfile(target, stm)
+
+        with pytest.raises(FileExistsError) as ex:
+            stm.save(target, overwrite=False)
+        assert ex.value.args[0] == f"{target} (use overwrite=True to ignore)"
+
+        stm.save(target, overwrite=True)
+        _checkfile(target, stm)
+
+        # Check non-null transformations.
+        i = 0
+        scalings = {None, *opinf.pre.SnapshotTransformer._VALID_SCALINGS}
+        for center, scaling in itertools.product((True, False), scalings):
+            stm.transformers[i].center = center
+            stm.transformers[i].scaling = scaling
+            i += 1
+        X = np.random.randint(0, 100, (150,17)).astype(float)
+        stm.fit_transform(X)
+        stm.save(target, overwrite=True)
+        _checkfile(target, stm)
+
+        os.remove(target)
+
+    def test_load(self, n=200, k=50):
+        """Test pre.SnapshotTransformerMulti.load()."""
+        # Clean up after old tests.
+        target = "_loadtransformermultitest.h5"
+        if os.path.isfile(target):              # pragma: no cover
+            os.remove(target)
+
+        # Try to load a bad file.
+        with h5py.File(target, 'w'):
+            pass
+
+        with pytest.raises(ValueError) as ex:
+            opinf.pre.SnapshotTransformerMulti.load(target)
+        assert ex.value.args[0] == "invalid save format (meta/ not found)"
+
+        # Check that save() -> load() gives the same transformer.
+        stm = opinf.pre.SnapshotTransformerMulti(15)
+        i = 0
+        scalings = {None, *opinf.pre.SnapshotTransformer._VALID_SCALINGS}
+        for center, scaling in itertools.product((True, False), scalings):
+            stm.transformers[i].center = center
+            stm.transformers[i].scaling = scaling
+            i += 1
+        X = np.random.randint(0, 100, (150,19)).astype(float)
+        stm.fit_transform(X)
+        stm.save(target, overwrite=True)
+        stm2 = opinf.pre.SnapshotTransformerMulti.load(target)
+        assert stm2 == stm
+
+        os.remove(target)
+
+    # Main routines -----------------------------------------------------------
+    def test_check_shape(self):
+        """Test pre.SnapshotTransformerMulti._check_shape()."""
+        stm = opinf.pre.SnapshotTransformerMulti(12)
+        stm.n_ = 10
+        X = np.random.randint(0, 100, (120,23)).astype(float)
+        stm._check_shape(X)
+
+        with pytest.raises(ValueError) as ex:
+            stm._check_shape(X[:-1])
+        assert ex.value.args[0] == \
+            "snapshot set must have num_variables * n = 12 * 10 = 120 rows " \
+            "(got 119)"
+
+    def __testcase(self):
+        centers = [
+            False, True,
+            False, False, False, False, False,
+            True, True, True, True, True,
+        ]
+        scalings = [
+            None, None,
+            "standard", "minmax", "minmaxsym", "maxabs", "maxabssym",
+            "standard", "minmax", "minmaxsym", "maxabs", "maxabssym"
+        ]
+        return opinf.pre.SnapshotTransformerMulti(len(centers),
+                                                  center=centers,
+                                                  scaling=scalings,
+                                                  verbose=True)
+
+    def test_fit_transform(self):
+        """Test pre.SnapshotTransformerMulti.fit_transform()."""
+        stm = self.__testcase()
+
+        # Inplace transformation.
+        X = np.random.randint(0, 100, (120,29)).astype(float)
+        Y = stm.fit_transform(X, inplace=True)
+        assert stm.n_ == 10
+        assert stm._is_trained()
+        assert Y is X
+
+        # Non-inplace transformation.
+        X = np.random.randint(0, 100, (120,29)).astype(float)
+        Y = stm.fit_transform(X, inplace=False)
+        assert stm.n_ == 10
+        assert stm._is_trained()
+        assert Y is not X
+        assert type(Y) is type(X)
+        assert Y.shape == X.shape
+
+        # Null transformation.
+        i = 0
+        s = slice(i*stm.n_, (i+1)*stm.n_)
+        assert np.allclose(Y[s], X[s])
+        for attr in ("mean_", "scale_", "shift_"):
+            assert not hasattr(stm.transformers[i], attr)
+
+        # Centering only.
+        i += 1
+        s = slice(i*stm.n_, (i+1)*stm.n_)
+        µ = np.mean(X[s], axis=1)
+        assert np.allclose(Y[s], X[s] - µ.reshape(-1,1))
+        assert hasattr(stm.transformers[i], "mean_")
+        assert np.allclose(stm.transformers[i].mean_, µ)
+        for attr in ("scale_", "shift_"):
+            assert not hasattr(stm.transformers[i], attr)
+
+        for ctr in [False, True]:
+            # Standard scaling.
+            i += 1
+            s = slice(i*stm.n_, (i+1)*stm.n_)
+            assert stm.transformers[i].scaling == "standard"
+            assert np.isclose(np.mean(Y[s]), 0)
+            assert np.isclose(np.std(Y[s]), 1)
+
+            # Minmax scaling (to [0,1]).
+            i += 1
+            s = slice(i*stm.n_, (i+1)*stm.n_)
+            assert stm.transformers[i].scaling == "minmax"
+            assert np.isclose(np.min(Y[s]), 0)
+            assert np.isclose(np.max(Y[s]), 1)
+
+            # Symmetric Minmax scaling (to [-1,1]).
+            i += 1
+            s = slice(i*stm.n_, (i+1)*stm.n_)
+            assert stm.transformers[i].scaling == "minmaxsym"
+            assert np.isclose(np.min(Y[s]), -1)
+            assert np.isclose(np.max(Y[s]), 1)
+
+            # Symmetric Minmax scaling (to [-1,1]).
+            i += 1
+            s = slice(i*stm.n_, (i+1)*stm.n_)
+            assert stm.transformers[i].scaling == "maxabs"
+            assert np.isclose(np.max(np.abs(Y[s])), 1)
+
+            # Symmetric Minmax scaling (to [-1,1]).
+            i += 1
+            s = slice(i*stm.n_, (i+1)*stm.n_)
+            assert stm.transformers[i].scaling == "maxabssym"
+            assert np.isclose(np.mean(Y[s]), 0)
+            assert np.isclose(np.max(np.abs(Y[s])), 1)
+
+    def test_transform(self):
+        """Test pre.SnapshotTransformerMulti.transform()."""
+        stm = self.__testcase()
+
+        X = np.random.randint(0, 100, (120,29)).astype(float)
+        with pytest.raises(AttributeError) as ex:
+            stm.inverse_transform(X, inplace=False)
+        assert ex.value.args[0] == \
+            "transformer not trained (call fit_transform())"
+
+        # Inplace transformation.
+        stm.fit_transform(X)
+        Y = np.random.randint(0, 100, (120,33)).astype(float)
+        Z = stm.transform(Y, inplace=True)
+        assert Z is Y
+
+        # Non-inplace transformation.
+        Y = np.random.randint(0, 100, (120,33)).astype(float)
+        Z = stm.transform(Y, inplace=False)
+        assert Z is not Y
+        assert type(Z) is type(Y)
+        assert Z.shape == Y.shape
+
+    def test_inverse_transform(self):
+        """Test pre.SnapshotTransformerMulti.transform()."""
+        stm = self.__testcase()
+
+        X = np.random.randint(0, 100, (120,29)).astype(float)
+        with pytest.raises(AttributeError) as ex:
+            stm.inverse_transform(X, inplace=False)
+        assert ex.value.args[0] == \
+            "transformer not trained (call fit_transform())"
+
+        # Inplace transformation.
+        stm.fit_transform(X)
+        Y = np.random.randint(0, 100, (120,32)).astype(float)
+        Z = stm.transform(Y, inplace=False)
+        W = stm.inverse_transform(Z, inplace=True)
+        assert W is Z
+
+        Z = stm.transform(Y, inplace=False)
+        W = stm.inverse_transform(Z, inplace=False)
+        assert W is not Z
+        assert np.allclose(W, Y)

--- a/tests/pre/test_shift_scale.py
+++ b/tests/pre/test_shift_scale.py
@@ -2,6 +2,7 @@
 """Tests for rom_operator_inference.pre._shift_scale.py."""
 
 import pytest
+import itertools
 import numpy as np
 
 import rom_operator_inference as opinf
@@ -65,3 +66,147 @@ def test_scale(set_up_basis_data):
 
     # Verify inverse scaling.
     assert np.allclose(opinf.pre.scale(Xscaled, scaled_from, scaled_to), X)
+
+
+class TestSnapshotTransformer:
+    """Test pre.SnapshotTransformer."""
+    def test_init(self):
+        """Test pre.SnapshotTransformer.__init__()."""
+        st = opinf.pre.SnapshotTransformer()
+        for attr in ["scaling", "center", "verbose"]:
+            assert hasattr(st, attr)
+
+    def test_properties(self):
+        """Test pre.SnapshotTransformer properties (attribute protection)."""
+        st = opinf.pre.SnapshotTransformer()
+
+        # Test scale.
+        with pytest.raises(ValueError) as exc:
+            st.scaling = "minimaxii"
+        assert exc.value.args[0].startswith("invalid scaling 'minimaxii'")
+
+        with pytest.raises(TypeError) as exc:
+            st.scaling = [2, 1]
+        assert exc.value.args[0] == "'scaling' must be of type 'str'"
+
+        for s in st._VALID_SCALINGS:
+            st.scaling = s
+        st.scaling = None
+
+    def test_fit_transform(self, n=200, k=50):
+        """Test pre.SnapshotTransformer.fit_transform()."""
+
+        def fit_transform_copy(st, A):
+            """Assert A and B are not the same object but do have the same
+            type and shape.
+            """
+            B = st.fit_transform(A, inplace=False)
+            assert B is not A
+            assert type(B) is type(A)
+            assert B.shape == A.shape
+            return B
+
+        X = np.random.randint(0, 100, (n,k)).astype(float)
+        st = opinf.pre.SnapshotTransformer(scaling=None,
+                                           center=False, verbose=0)
+
+        # Test null transformation.
+        Y = st.fit_transform(X, inplace=True)
+        assert Y is X
+        X = np.random.randint(0, 100, (n,k)).astype(float)
+        Y = fit_transform_copy(st, X)
+        assert np.all(Y == X)
+
+        # Test standard scaling.
+        st.scaling = "standard"
+        Y = fit_transform_copy(st, X)
+        for attr in "scale_", "shift_":
+            assert hasattr(st, attr)
+            assert isinstance(getattr(st, attr), float)
+        assert np.isclose(np.mean(Y), 0)
+        assert np.isclose(np.std(Y), 1)
+
+        # Test min-max scaling.
+        st.scaling = "minmax"
+        Y = fit_transform_copy(st, X)
+        assert np.isclose(np.min(Y), 0)
+        assert np.isclose(np.max(Y), 1)
+
+        # Test min-max scaling.
+        st.scaling = "symminmax"
+        Y = fit_transform_copy(st, X)
+        assert np.isclose(np.min(Y), -1)
+        assert np.isclose(np.max(Y), 1)
+
+        # Test maximum absolute scaling.
+        st.scaling = "maxabs"
+        Y = fit_transform_copy(st, X)
+        assert np.isclose(np.max(np.abs(Y)), 1)
+
+        # Test minimum-maximum absolute scaling.
+        st.scaling = "minmaxabs"
+        Y = fit_transform_copy(st, X)
+        assert np.isclose(np.mean(Y), 0)
+        assert np.isclose(np.max(np.abs(Y)), 1)
+
+        # Test mean shift.
+        st.center = True
+        Y = fit_transform_copy(st, X)
+        assert hasattr(st, "mean_")
+        assert isinstance(st.mean_, np.ndarray)
+        assert st.mean_.shape == (X.shape[0],)
+        assert np.allclose(np.mean(Y, axis=1), 0)
+
+    def test_transform(self, n=200, k=50):
+        """Test pre.SnapshotTransformer.transform()."""
+        X = np.random.randint(0, 100, (n,k)).astype(float)
+        st = opinf.pre.SnapshotTransformer(scaling=None,
+                                           center=False, verbose=0)
+
+        # Test null transformation.
+        X = np.random.randint(0, 100, (n,k)).astype(float)
+        st.fit_transform(X)
+        Y = np.random.randint(0, 100, (n,k)).astype(float)
+        Z = st.transform(Y, inplace=True)
+        assert Z is Y
+        Y = np.random.randint(0, 100, (n,k)).astype(float)
+        Z = st.transform(Y, inplace=False)
+        assert Z is not Y
+        assert Z.shape == Y.shape
+        assert np.all(Z == Y)
+
+        # Test each scaling.
+        for scl in st._VALID_SCALINGS:
+            X = np.random.randint(0, 100, (n,k)).astype(float)
+            Y = np.random.randint(0, 100, (n,k)).astype(float)
+            st.scaling = scl
+            st.fit_transform(X)
+            a, b = st.scale_, st.shift_
+            Z = st.transform(Y)
+            assert np.allclose(Z, a*Y + b)
+
+        # Test mean shift.
+        st.center = True
+        st.scaling = None
+        X = np.random.randint(0, 100, (n,k)).astype(float)
+        Y = np.random.randint(0, 100, (n,k)).astype(float)
+        st.fit_transform(X)
+        µ = st.mean_
+        Z = st.transform(Y)
+        assert np.allclose(Z, Y - µ.reshape(-1,1))
+
+    def test_inverse_transform(self, n=200, k=50):
+        """Test pre.SnapshotTransformer.transform()."""
+        X = np.random.randint(0, 100, (n,k)).astype(float)
+        st = opinf.pre.SnapshotTransformer(scaling=None,
+                                           center=False, verbose=0)
+
+        for scaling, center in itertools.product({None, *st._VALID_SCALINGS},
+                                                 (True, False)):
+            st.scaling = scaling
+            st.center = center
+            st.fit_transform(X, inplace=False)
+            Y = np.random.randint(0, 100, (n,k)).astype(float)
+            Z = st.transform(Y, inplace=False)
+            st.inverse_transform(Z, inplace=True)
+            assert np.allclose(Z, Y)

--- a/tests/pre/test_shift_scale.py
+++ b/tests/pre/test_shift_scale.py
@@ -802,7 +802,7 @@ class TestSnapshotTransformerMulti:
 
         X = np.random.randint(0, 100, (120,29)).astype(float)
         with pytest.raises(AttributeError) as ex:
-            stm.inverse_transform(X, inplace=False)
+            stm.transform(X, inplace=False)
         assert ex.value.args[0] == \
             "transformer not trained (call fit_transform())"
 


### PR DESCRIPTION
Two new classes in the `pre` module for handling snapshot preprocessing:
- `pre.SnapshotTransformer`: learn a centering and/or non-dimensionalization transformation for a snapshot set representing a single variable.
- `pre.SnapshotTransformerMulti`: join multiple `SnapshotTransformer`s together for data sets with multiple variables (which may be preprocessed in different ways).